### PR TITLE
https://github.com/vartanbeno/go-reddit/pull/21

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ROOT_PKG ?= "github.com/vartanbeno/go-reddit"
+ROOT_PKG ?= "github.com/sethjones/go-reddit"
 LIST_PKG := $(shell go list $(ROOT_PKG)/...)
 
 # Tests

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 <div id='badges' align='center'>
 
-[![Actions Status](https://github.com/vartanbeno/go-reddit/workflows/tests/badge.svg)](https://github.com/vartanbeno/go-reddit/actions)
-[![Go Report Card](https://goreportcard.com/badge/github.com/vartanbeno/go-reddit)](https://goreportcard.com/report/github.com/vartanbeno/go-reddit)
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/vartanbeno/go-reddit/v2/reddit)](https://pkg.go.dev/github.com/vartanbeno/go-reddit/v2/reddit)
+[![Actions Status](https://github.com/sethjones/go-reddit/workflows/tests/badge.svg)](https://github.com/sethjones/go-reddit/actions)
+[![Go Report Card](https://goreportcard.com/badge/github.com/sethjones/go-reddit)](https://goreportcard.com/report/github.com/sethjones/go-reddit)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/sethjones/go-reddit/v2/reddit)](https://pkg.go.dev/github.com/sethjones/go-reddit/v2/reddit)
 
 </div>
 
@@ -24,16 +24,16 @@ You can view Reddit's official API documentation [here](https://www.reddit.com/d
 
 ## Install
 
-To get a specific version from the list of [versions](https://github.com/vartanbeno/go-reddit/releases):
+To get a specific version from the list of [versions](https://github.com/sethjones/go-reddit/releases):
 
 ```sh
-go get github.com/vartanbeno/go-reddit/v2@vX.Y.Z
+go get github.com/sethjones/go-reddit/v2@vX.Y.Z
 ```
 
 Or for the latest version:
 
 ```sh
-go get github.com/vartanbeno/go-reddit/v2
+go get github.com/sethjones/go-reddit/v2
 ```
 
 The repository structure for managing multiple major versions follows the one outlined [here](https://github.com/go-modules-by-example/index/tree/master/016_major_version_repo_strategy#major-branch-strategy).
@@ -45,7 +45,7 @@ Make sure to have a Reddit app with a valid client id and secret. [Here](https:/
 ```go
 package main
 
-import "github.com/vartanbeno/go-reddit/v2/reddit"
+import "github.com/sethjones/go-reddit/v2/reddit"
 
 func main() {
     credentials := reddit.Credentials{ID: "id", Secret: "secret", Username: "username", Password: "password"}

--- a/examples/client-on-request-completed/main.go
+++ b/examples/client-on-request-completed/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/vartanbeno/go-reddit/v2/reddit"
+	"github.com/sethjones/go-reddit/v2/reddit"
 )
 
 var ctx = context.Background()

--- a/examples/get-subreddit/main.go
+++ b/examples/get-subreddit/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/vartanbeno/go-reddit/v2/reddit"
+	"github.com/sethjones/go-reddit/v2/reddit"
 )
 
 var ctx = context.Background()

--- a/examples/get-top-posts/main.go
+++ b/examples/get-top-posts/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/vartanbeno/go-reddit/v2/reddit"
+	"github.com/sethjones/go-reddit/v2/reddit"
 )
 
 var ctx = context.Background()

--- a/examples/stream-posts/main.go
+++ b/examples/stream-posts/main.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/vartanbeno/go-reddit/v2/reddit"
+	"github.com/sethjones/go-reddit/v2/reddit"
 )
 
 var ctx = context.Background()

--- a/examples/submit-post/main.go
+++ b/examples/submit-post/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/vartanbeno/go-reddit/v2/reddit"
+	"github.com/sethjones/go-reddit/v2/reddit"
 )
 
 var ctx = context.Background()

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vartanbeno/go-reddit/v2
+module github.com/sethjones/go-reddit/v2
 
 go 1.15
 

--- a/reddit/reddit-options.go
+++ b/reddit/reddit-options.go
@@ -55,6 +55,16 @@ func WithTokenURL(u string) Opt {
 	}
 }
 
+// WithApplicationOnlyOAuth sets authentication flow to "Application Only OAuth".
+// Only ID and Secret are required to be set in client. Username and Password are ignored.
+// The flow is described here: https://github.com/reddit-archive/reddit/wiki/OAuth2#application-only-oauth
+func WithApplicationOnlyOAuth(o bool) Opt {
+	return func(c *Client) error {
+		c.applicationOnlyOAuth = o
+		return nil
+	}
+}
+
 // FromEnv configures the client with values from environment variables.
 // Supported environment variables:
 // GO_REDDIT_CLIENT_ID to set the client's id.

--- a/reddit/reddit-options_test.go
+++ b/reddit/reddit-options_test.go
@@ -1,13 +1,17 @@
 package reddit
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 )
 
 func TestWithHTTPClient(t *testing.T) {
@@ -50,6 +54,28 @@ func TestWithTokenURL(t *testing.T) {
 	c, err = NewClient(Credentials{}, WithTokenURL(tokenURL))
 	require.NoError(t, err)
 	require.Equal(t, tokenURL, c.TokenURL.String())
+}
+
+type RequestInterceptor struct {
+	interceptedBody string
+}
+
+func (t *RequestInterceptor) RoundTrip(r *http.Request) (*http.Response, error) {
+	requestBody, _ := ioutil.ReadAll(r.Body)
+	t.interceptedBody = string(requestBody)
+	var body bytes.Buffer
+	body.WriteString(`{"access_token": "foobar", "expires_in": 3600, "scope": "*", "token_type": "bearer"}`)
+	return &http.Response{Status: "200 OK", StatusCode: 200, Body: io.NopCloser(&body)}, nil
+}
+
+func TestWithApplicationOnlyOAuth(t *testing.T) {
+	requestInterceptor := &RequestInterceptor{}
+	c, err := NewClient(Credentials{ID: "id", Secret: "secret"}, WithApplicationOnlyOAuth(true), WithHTTPClient(&http.Client{Transport: requestInterceptor}))
+	require.NoError(t, err)
+	token, err := c.client.Transport.(*oauth2.Transport).Source.Token()
+	require.NoError(t, err)
+	require.Equal(t, token.AccessToken, "foobar")
+	require.Equal(t, "grant_type=client_credentials", requestInterceptor.interceptedBody)
 }
 
 func TestFromEnv(t *testing.T) {

--- a/reddit/reddit-options_test.go
+++ b/reddit/reddit-options_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -61,7 +60,7 @@ type RequestInterceptor struct {
 }
 
 func (t *RequestInterceptor) RoundTrip(r *http.Request) (*http.Response, error) {
-	requestBody, _ := ioutil.ReadAll(r.Body)
+	requestBody, _ := io.ReadAll(r.Body)
 	t.interceptedBody = string(requestBody)
 	var body bytes.Buffer
 	body.WriteString(`{"access_token": "foobar", "expires_in": 3600, "scope": "*", "token_type": "bearer"}`)

--- a/reddit/reddit.go
+++ b/reddit/reddit.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/google/go-querystring/query"
-	"golang.org/x/oauth2"
 )
 
 const (
@@ -96,7 +95,7 @@ type Client struct {
 	Widget     *WidgetService
 	Wiki       *WikiService
 
-	oauth2Transport *oauth2.Transport
+	applicationOnlyOAuth bool
 
 	onRequestCompleted RequestCompletionCallback
 }

--- a/reddit/reddit.go
+++ b/reddit/reddit.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	libraryName    = "github.com/vartanbeno/go-reddit"
-	libraryVersion = "2.0.0"
+	libraryName    = "github.com/sethjones/go-reddit"
+	libraryVersion = "2.0.1"
 
 	defaultBaseURL         = "https://oauth.reddit.com"
 	defaultBaseURLReadonly = "https://reddit.com"


### PR DESCRIPTION
Clone of: https://github.com/vartanbeno/go-reddit/pull/21


This PR implements Application Only OAuth (also known as "two-legged oauth").

This is NOT a breaking change and is fully backwards-compatible. Default behavior is unaffected.

This flow is activated with WithApplicationOnlyOAuth(o bool) option:

    o == true: oauthTransport uses "golang.org/x/oauth2/clientcredentials"
    o == false: oauthTransport uses "golang.org/x/oauth2" (default behavior)

See https://github.com/vartanbeno/go-reddit/issues/18 for discussion: https://github.com/vartanbeno/go-reddit/issues/18#issuecomment-890094080

Usage example:

package main

import (
	"context"
	"fmt"

	"github.com/and3rson/go-reddit/v2/reddit"
)

func main() {
	client, err := reddit.NewClient(reddit.Credentials{
		ID:     "your_client_id",
		Secret: "your_client_secret",
	}, reddit.WithUserAgent("my-application"), reddit.WithApplicationOnlyOAuth(true))
	if err != nil {
		panic(err)
	}
	posts, err := client.Subreddit.TopPosts(context.Background(), "funny", &reddit.ListPostOptions{})
	if err != nil {
		panic(err)
	}
	fmt.Println(posts)
}

Unit test included.